### PR TITLE
droid4 accelerometer fix

### DIFF
--- a/drivers/i2c/algos/i2c-algo-bit.c
+++ b/drivers/i2c/algos/i2c-algo-bit.c
@@ -492,7 +492,7 @@ static int bit_doAddress(struct i2c_adapter *i2c_adap, struct i2c_msg *msg)
 
 	if (flags & I2C_M_TEN) {
 		/* a ten bit address */
-		addr = 0xf0 | ((msg->addr >> 7) & 0x03);
+		addr = 0xf0 | ((msg->addr >> 7) & 0x06);
 		bit_dbg(2, &i2c_adap->dev, "addr0: %d\n", addr);
 		/* try extended address code...*/
 		ret = try_address(i2c_adap, addr, retries);
@@ -502,7 +502,7 @@ static int bit_doAddress(struct i2c_adapter *i2c_adap, struct i2c_msg *msg)
 			return -EREMOTEIO;
 		}
 		/* the remaining 8 bit address */
-		ret = i2c_outb(i2c_adap, msg->addr & 0x7f);
+		ret = i2c_outb(i2c_adap, msg->addr & 0xff);
 		if ((ret != 1) && !nak_ok) {
 			/* the chip did not ack / xmission error occurred */
 			dev_err(&i2c_adap->dev, "died at 2nd address code\n");

--- a/drivers/misc/lis3dh.c
+++ b/drivers/misc/lis3dh.c
@@ -118,30 +118,9 @@ static struct notifier_block lis3dh_pm_notifier;
 
 static int lis3dh_i2c_read(struct lis3dh_data *lis, u8 * buf, int len)
 {
-	int err;
-	int tries = 0;
-	struct i2c_msg msgs[] = {
-		{
-		 .addr = lis->client->addr,
-		 .flags = lis->client->flags & I2C_M_TEN,
-		 .len = 1,
-		 .buf = buf,
-		 },
-		{
-		 .addr = lis->client->addr,
-		 .flags = (lis->client->flags & I2C_M_TEN) | I2C_M_RD,
-		 .len = len,
-		 .buf = buf,
-		 },
-	};
-
-	do {
-		err = i2c_transfer(lis->client->adapter, msgs, 2);
-		if (err != 2)
-			msleep_interruptible(I2C_RETRY_DELAY);
-	} while ((err != 2) && (++tries < I2C_RETRIES));
-
-	if (err != 2) {
+	lis->client->flags = 0;
+	int err = i2c_smbus_read_i2c_block_data(lis->client, buf[0], len, buf);
+	if (err != len) {
 		dev_err(&lis->client->dev, "read transfer error\n");
 		err = -EIO;
 	} else {
@@ -153,24 +132,9 @@ static int lis3dh_i2c_read(struct lis3dh_data *lis, u8 * buf, int len)
 
 static int lis3dh_i2c_write(struct lis3dh_data *lis, u8 * buf, int len)
 {
-	int err;
-	int tries = 0;
-	struct i2c_msg msgs[] = {
-		{
-		 .addr = lis->client->addr,
-		 .flags = lis->client->flags & I2C_M_TEN,
-		 .len = len + 1,
-		 .buf = buf,
-		 },
-	};
-
-	do {
-		err = i2c_transfer(lis->client->adapter, msgs, 1);
-		if (err != 1)
-			msleep_interruptible(I2C_RETRY_DELAY);
-	} while ((err != 1) && (++tries < I2C_RETRIES));
-
-	if (err != 1) {
+	lis->client->flags = 0;
+	int err = i2c_smbus_write_i2c_block_data(lis->client, buf[0], len, buf+1);
+	if (err) {
 		dev_err(&lis->client->dev, "write transfer error\n");
 		err = -EIO;
 	} else {


### PR DESCRIPTION
Fixes accelerometer using latest cm-10.1 nightly.

I wonder why the vendor driver asks for 10-bit transfers even though it's an 8-bit device? Yuck.
